### PR TITLE
Fix DEEPSLATE_REDSTONE_ORE

### DIFF
--- a/src/main/java/com/winthier/exploits/PlayerPlacedBlocks.java
+++ b/src/main/java/com/winthier/exploits/PlayerPlacedBlocks.java
@@ -183,7 +183,7 @@ final class PlayerPlacedBlocks implements Listener {
     void onEntityChangeBlock(EntityChangeBlockEvent event) {
         if (event.getTo() == Material.AIR) {
             setPlayerPlaced(event.getBlock(), false);
-        } else if (event.getTo() == Material.REDSTONE_ORE) {
+        } else if (event.getTo() == Material.REDSTONE_ORE || event.getTo() == Material.DEEPSLATE_REDSTONE_ORE) {
             return;
         } else {
             setPlayerPlaced(event.getBlock(), true);


### PR DESCRIPTION
Deepslate Redstone Ore is no longer marked as player placed when it lights up